### PR TITLE
refactor: rename fasta_processor to fasta for better CLI consistency

### DIFF
--- a/src/bio2parquet/__init__.py
+++ b/src/bio2parquet/__init__.py
@@ -25,4 +25,4 @@ except importlib.metadata.PackageNotFoundError:
 
 from bio2parquet.cli import main
 from bio2parquet.errors import Bio2ParquetError, FileProcessingError, InvalidFormatError, print_error
-from bio2parquet.fasta_processor import create_dataset_from_fasta, read_fasta_file
+from bio2parquet.fasta import create_dataset_from_fasta, read_fasta_file

--- a/src/bio2parquet/cli.py
+++ b/src/bio2parquet/cli.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from datasets import Dataset
 
 from bio2parquet.errors import Bio2ParquetError, print_error
-from bio2parquet.fasta_processor import create_dataset_from_fasta
+from bio2parquet.fasta import create_dataset_from_fasta
 
 
 def _handle_empty_dataset(dataset: "Dataset") -> None:

--- a/src/bio2parquet/fasta.py
+++ b/src/bio2parquet/fasta.py
@@ -1,0 +1,148 @@
+"""FASTA file processing and conversion to Parquet datasets."""
+
+import gzip
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from datasets import Dataset, Features, Value
+
+from bio2parquet.errors import FileProcessingError, InvalidFormatError
+
+
+def _handle_fasta_parsing_error(*, condition: bool, message: str, filepath_str: str) -> None:
+    """Helper function to raise InvalidFormatError if a condition is met."""
+    if condition:
+        raise InvalidFormatError(message, filepath_str)
+
+
+def open_gz_file_text(fp: Path, m: str) -> Any:
+    """Open a GZIP file with text mode."""
+    return gzip.open(fp, m, encoding="utf-8")
+
+
+def read_fasta_file(filepath: Path) -> Iterator[dict[str, str]]:
+    """Reads a FASTA file and yields records as dictionaries.
+
+    Handles both .fasta and .fasta.gz files.
+
+    Args:
+        filepath: Path to the FASTA file.
+
+    Yields:
+        A dictionary with 'header' and 'sequence' keys for each record.
+
+    Raises:
+        FileProcessingError: If the file cannot be read.
+        InvalidFormatError: If the file is not in valid FASTA format.
+    """
+    if not filepath.exists():
+        raise FileProcessingError(f"Input file does not exist: {filepath}", str(filepath))
+    if not filepath.is_file():
+        raise FileProcessingError(f"Input path is not a file: {filepath}", str(filepath))
+
+    file_opener: Callable
+    if filepath.name.endswith(".gz"):
+        file_opener = open_gz_file_text
+        mode = "rt"
+    else:
+        file_opener = open
+        mode = "r"
+
+    try:
+        with file_opener(filepath, mode) as f:
+            header: Optional[str] = None
+            sequence_parts: list[str] = []
+            for current_line in f:
+                line = current_line.strip()
+                if not line:
+                    continue  # Skip empty lines
+                if line.startswith(">"):
+                    if header is not None:
+                        # Yield previous record
+                        if not sequence_parts:
+                            _handle_fasta_parsing_error(
+                                condition=True,
+                                message="Sequence missing for header.",
+                                filepath_str=str(filepath),
+                            )
+                        yield {"header": header, "sequence": "".join(sequence_parts)}
+                    header = line[1:]  # Remove '>'
+                    sequence_parts = []
+                elif header is not None:  # sequence line
+                    sequence_parts.append(line)
+                else:
+                    # This means a sequence line appeared before any header
+                    _handle_fasta_parsing_error(
+                        condition=True,
+                        message="Sequence data found before a header line.",
+                        filepath_str=str(filepath),
+                    )
+
+            # Yield the last record in the file
+            if header is not None and sequence_parts:
+                yield {"header": header, "sequence": "".join(sequence_parts)}
+            elif header is not None and not sequence_parts:
+                _handle_fasta_parsing_error(
+                    condition=True,
+                    message="Sequence missing for the last header.",
+                    filepath_str=str(filepath),
+                )
+            elif header is None and not sequence_parts and filepath.stat().st_size > 0:
+                # File is not empty but no headers or sequences were found
+                _handle_fasta_parsing_error(
+                    condition=True,
+                    message="File does not appear to be in FASTA format.",
+                    filepath_str=str(filepath),
+                )
+
+    except FileNotFoundError:
+        raise FileProcessingError(f"File not found: {filepath}", str(filepath)) from None
+    except gzip.BadGzipFile:
+        raise FileProcessingError(f"File is not a valid GZIP file: {filepath}", str(filepath)) from None
+    except (InvalidFormatError, FileProcessingError):  # Re-raise specific errors directly
+        raise
+    except Exception as e:
+        raise FileProcessingError(f"Error reading file {filepath}: {e}", str(filepath)) from e
+
+
+def create_dataset_from_fasta(filepath: Path) -> Dataset:
+    """Creates a Hugging Face Dataset from a FASTA file.
+
+    Args:
+        filepath: Path to the FASTA file.
+
+    Returns:
+        A Hugging Face Dataset with 'header' and 'sequence' columns.
+
+    Raises:
+        AssertionError: If the input filepath does not exist or is not a file.
+    """
+    if not filepath.exists():
+        raise FileProcessingError(f"Input file does not exist: {filepath}", str(filepath))
+    if not filepath.is_file():
+        raise FileProcessingError(f"Input path is not a file: {filepath}", str(filepath))
+
+    features = Features(
+        {
+            "header": Value("string"),
+            "sequence": Value("string"),
+        },
+    )
+
+    # Check if the generator will be empty to avoid issues with Dataset.from_generator
+    # This is a bit inefficient as it might iterate twice in the worst case (once for check, once for generation)
+    # but ensures robustness for empty or malformed-but-not-raising files.
+    # A more optimized way might involve peeking the generator or modifying read_fasta_file.
+
+    # Convert iterator to list to check if it's empty and to reuse it.
+    records = list(read_fasta_file(filepath))
+
+    if not records:
+        # Return an empty dataset with the correct schema
+        return Dataset.from_dict({"header": [], "sequence": []}, features=features)
+
+    def gen() -> Iterator[dict[str, str]]:
+        yield from records
+
+    return Dataset.from_generator(gen, features=features)

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+
+import pytest
+from datasets import Dataset
+
+from bio2parquet.errors import FileProcessingError, InvalidFormatError
+from bio2parquet.fasta import create_dataset_from_fasta, read_fasta_file
+
+
+@pytest.fixture
+def sample_fasta_file(tmp_path: Path) -> Path:
+    content = ">Seq1;info1\nATGCATGC\nCGTACGTA\n>Seq2;info2\nGATTACAGATTACA\n>Seq3;info3\nCCCCGGGGTTTTAAAA"
+    file_path = tmp_path / "test.fasta"
+    file_path.write_text(content)
+    assert file_path.exists(), "Test FASTA file was not created."
+    return file_path
+
+
+@pytest.fixture
+def sample_fasta_gz_file(tmp_path: Path, sample_fasta_file: Path) -> Path:
+    import gzip
+
+    gz_file_path = tmp_path / "test.fasta.gz"
+    with open(sample_fasta_file, "rb") as f_in, gzip.open(gz_file_path, "wb") as f_out:
+        f_out.write(f_in.read())
+    assert gz_file_path.exists(), "Test gzipped FASTA file was not created."
+    return gz_file_path
+
+
+@pytest.fixture
+def empty_fasta_file(tmp_path: Path) -> Path:
+    file_path = tmp_path / "empty.fasta"
+    file_path.touch()
+    assert file_path.exists(), "Empty test FASTA file was not created."
+    return file_path
+
+
+@pytest.fixture
+def malformed_fasta_file_no_header(tmp_path: Path) -> Path:
+    content = "ATGCATGC\nCGTACGTA"
+    file_path = tmp_path / "no_header.fasta"
+    file_path.write_text(content)
+    assert file_path.exists(), "Malformed (no header) FASTA file was not created."
+    return file_path
+
+
+@pytest.fixture
+def malformed_fasta_file_no_sequence(tmp_path: Path) -> Path:
+    content = ">Seq1\n>Seq2"
+    file_path = tmp_path / "no_sequence.fasta"
+    file_path.write_text(content)
+    assert file_path.exists(), "Malformed (no sequence) FASTA file was not created."
+    return file_path
+
+
+@pytest.mark.parametrize("file_fixture_name", ["sample_fasta_file", "sample_fasta_gz_file"])
+def test_read_fasta_file_valid(file_fixture_name: str, request: pytest.FixtureRequest) -> None:
+    fasta_file = request.getfixturevalue(file_fixture_name)
+    records = list(read_fasta_file(fasta_file))
+
+    assert len(records) == 3, "Incorrect number of records read."
+    assert records[0]["header"] == "Seq1;info1", "Header for Seq1 is incorrect."
+    assert records[0]["sequence"] == "ATGCATGCCGTACGTA", "Sequence for Seq1 is incorrect."
+    assert records[1]["header"] == "Seq2;info2", "Header for Seq2 is incorrect."
+    assert records[1]["sequence"] == "GATTACAGATTACA", "Sequence for Seq2 is incorrect."
+    assert records[2]["header"] == "Seq3;info3", "Header for Seq3 is incorrect."
+    assert records[2]["sequence"] == "CCCCGGGGTTTTAAAA", "Sequence for Seq3 is incorrect."
+
+
+def test_read_fasta_file_empty(empty_fasta_file: Path) -> None:
+    records = list(read_fasta_file(empty_fasta_file))
+    assert len(records) == 0, "Reading an empty FASTA file should yield no records."
+
+
+def test_read_fasta_file_no_header_error(malformed_fasta_file_no_header: Path) -> None:
+    with pytest.raises(InvalidFormatError) as excinfo:
+        list(read_fasta_file(malformed_fasta_file_no_header))
+    assert "Sequence data found before a header line" in str(excinfo.value), "Incorrect error for FASTA without header."
+    assert str(malformed_fasta_file_no_header) in str(excinfo.value)
+
+
+def test_read_fasta_file_no_sequence_error(malformed_fasta_file_no_sequence: Path) -> None:
+    with pytest.raises(InvalidFormatError) as excinfo:
+        list(read_fasta_file(malformed_fasta_file_no_sequence))
+    assert "Sequence missing for header." in str(excinfo.value) or "Sequence missing for the last header." in str(
+        excinfo.value,
+    ), "Incorrect error for FASTA with missing sequence."
+    assert str(malformed_fasta_file_no_sequence) in str(excinfo.value)
+
+
+def test_read_fasta_file_non_existent() -> None:
+    with pytest.raises(FileProcessingError) as excinfo:
+        list(read_fasta_file(Path("non_existent_file.fasta")))
+    assert "Input file does not exist" in str(excinfo.value), "Incorrect error for non-existent file."
+
+
+@pytest.mark.parametrize("file_fixture_name", ["sample_fasta_file", "sample_fasta_gz_file"])
+def test_create_dataset_from_fasta_valid(file_fixture_name: str, request: pytest.FixtureRequest) -> None:
+    fasta_file = request.getfixturevalue(file_fixture_name)
+    dataset = create_dataset_from_fasta(fasta_file)
+
+    assert isinstance(dataset, Dataset), "The result should be a Hugging Face Dataset."
+    assert len(dataset) == 3, "Dataset has incorrect number of rows."
+    assert list(dataset.column_names) == ["header", "sequence"], "Dataset has incorrect column names."
+
+    assert dataset[0]["header"] == "Seq1;info1", "Dataset header for Seq1 is incorrect."
+    assert dataset[0]["sequence"] == "ATGCATGCCGTACGTA", "Dataset sequence for Seq1 is incorrect."
+    assert dataset[2]["header"] == "Seq3;info3", "Dataset header for Seq3 is incorrect."
+    assert dataset[2]["sequence"] == "CCCCGGGGTTTTAAAA", "Dataset sequence for Seq3 is incorrect."
+
+
+def test_create_dataset_from_empty_fasta(empty_fasta_file: Path) -> None:
+    # Expect this to create an empty dataset without raising an error during generation
+    # The CLI will later assert that the dataset is not empty.
+    dataset = create_dataset_from_fasta(empty_fasta_file)
+    assert isinstance(dataset, Dataset), "The result should be a Hugging Face Dataset even for empty input."
+    assert len(dataset) == 0, "Dataset from empty FASTA should be empty."
+    assert list(dataset.column_names) == ["header", "sequence"], "Dataset from empty FASTA has incorrect columns."
+
+
+def test_create_dataset_from_fasta_non_existent() -> None:
+    with pytest.raises(FileProcessingError) as excinfo:
+        create_dataset_from_fasta(Path("non_existent_file.fasta"))
+    assert "Input file does not exist" in str(excinfo.value), (
+        "Incorrect error for non-existent file when creating dataset."
+    )
+
+
+def test_fasta_assertions() -> None:
+    """Test assertions within fasta functions."""
+    # Test read_fasta_file assertions
+    with pytest.raises(FileProcessingError, match="Input file does not exist"):
+        list(read_fasta_file(Path("nonexistent.fasta")))
+
+    with pytest.raises(FileProcessingError, match="Input path is not a file"):
+        list(read_fasta_file(Path(".")))  # Current directory
+
+    # Test create_dataset_from_fasta assertions
+    with pytest.raises(FileProcessingError, match="Input file does not exist"):
+        create_dataset_from_fasta(Path("nonexistent.fasta"))
+
+    with pytest.raises(FileProcessingError, match="Input path is not a file"):
+        create_dataset_from_fasta(Path("."))  # Current directory


### PR DESCRIPTION
This PR renames fasta_processor.py to fasta.py to better align with the CLI implementation and make the codebase more intuitive regarding the cli.