### PR TITLE
feat: add CSV to Parquet conversion support with CLI and tests

### DIFF
--- a/src/bio2parquet/cli.py
+++ b/src/bio2parquet/cli.py
@@ -12,9 +12,9 @@ import click
 if TYPE_CHECKING:
     from datasets import Dataset
 
+from bio2parquet.csv import create_dataset_from_csv
 from bio2parquet.errors import Bio2ParquetError, print_error
 from bio2parquet.fasta import create_dataset_from_fasta
-from bio2parquet.csv import create_dataset_from_csv
 
 
 def _handle_empty_dataset(dataset: "Dataset") -> None:

--- a/src/bio2parquet/csv.py
+++ b/src/bio2parquet/csv.py
@@ -3,19 +3,18 @@
 import csv
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, Optional
 
-from datasets import Dataset, Features, Value
+from datasets import Dataset
 
 from bio2parquet.errors import FileProcessingError, InvalidFormatError
 
 
 def _validate_file_exists(filepath: Path) -> None:
     """Validates that the file exists and is a file.
-    
+
     Args:
         filepath: Path to validate
-        
+
     Raises:
         FileProcessingError: If file doesn't exist or isn't a file
     """
@@ -27,10 +26,10 @@ def _validate_file_exists(filepath: Path) -> None:
 
 def _validate_csv_header(header: list[str]) -> None:
     """Validates that the CSV header contains required columns.
-    
+
     Args:
         header: List of column names from the CSV header
-        
+
     Raises:
         InvalidFormatError: If required columns are missing
     """
@@ -45,11 +44,11 @@ def _validate_csv_header(header: list[str]) -> None:
 
 def _raise_invalid_format_error(message: str, filepath_str: str) -> None:
     """Raises an InvalidFormatError with the given message.
-    
+
     Args:
         message: The error message
         filepath_str: The filepath as a string
-        
+
     Raises:
         InvalidFormatError: Always raises this exception
     """
@@ -80,9 +79,9 @@ def read_csv_file(filepath: Path) -> Iterator[dict[str, str]]:
                 header = next(reader)
             except StopIteration:
                 _raise_invalid_format_error("File is empty: no CSV records found.", str(filepath))
-            
+
             _validate_csv_header(header)
-            
+
             for row in reader:
                 if len(row) != len(header):
                     _raise_invalid_format_error(
@@ -90,7 +89,7 @@ def read_csv_file(filepath: Path) -> Iterator[dict[str, str]]:
                         str(filepath),
                     )
                 yield dict(zip(header, row))
-                
+
     except FileNotFoundError:
         raise FileProcessingError(f"File not found: {filepath}", str(filepath)) from None
     except InvalidFormatError:
@@ -100,7 +99,7 @@ def read_csv_file(filepath: Path) -> Iterator[dict[str, str]]:
 
 
 def create_dataset_from_csv(filepath: Path) -> Dataset:
-    """Creates a Hugging Face Dataset from a CSV file.
+    """Creates a Hugging Face Dataset from a CSV file with dynamic columns.
 
     Args:
         filepath: Path to the CSV file.
@@ -110,33 +109,22 @@ def create_dataset_from_csv(filepath: Path) -> Dataset:
 
     Raises:
         FileProcessingError: If the input filepath does not exist or is not a file.
-        InvalidFormatError: If the file is not in valid CSV format.
+        InvalidFormatError: If the file is not in valid CSV format or missing required columns.
     """
-    _validate_file_exists(filepath)
+    if not filepath.exists():
+        raise FileProcessingError(f"Input file does not exist: {filepath}", str(filepath))
+    if not filepath.is_file():
+        raise FileProcessingError(f"Input path is not a file: {filepath}", str(filepath))
 
-    # Read all records into memory
-    records = list(read_csv_file(filepath))
+    try:
+        dataset = Dataset.from_csv(str(filepath))
+    except Exception as e:
+        raise InvalidFormatError(f"Could not read CSV: {e}", str(filepath)) from e
 
-    if not records:
-        # Create empty dataset with correct features
-        features = Features(
-            {
-                "header": Value("string"),
-                "sequence": Value("string"),
-                "description": Value("string"),
-            },
-        )
-        return Dataset.from_dict({"header": [], "sequence": [], "description": []}, features=features)
+    # Check for required columns
+    required_columns = {"header", "sequence"}
+    missing = required_columns - set(dataset.column_names)
+    if missing:
+        raise InvalidFormatError(f"Missing required columns: {', '.join(missing)}", str(filepath))
 
-    # Create features from the first record
-    features = Features(
-        {
-            key: Value("string")
-            for key in records[0].keys()
-        },
-    )
-
-    def gen() -> Iterator[dict[str, str]]:
-        yield from records
-
-    return Dataset.from_generator(gen, features=features) 
+    return dataset

--- a/src/bio2parquet/csv.py
+++ b/src/bio2parquet/csv.py
@@ -1,0 +1,142 @@
+"""CSV file processing and conversion to Parquet datasets."""
+
+import csv
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, Optional
+
+from datasets import Dataset, Features, Value
+
+from bio2parquet.errors import FileProcessingError, InvalidFormatError
+
+
+def _validate_file_exists(filepath: Path) -> None:
+    """Validates that the file exists and is a file.
+    
+    Args:
+        filepath: Path to validate
+        
+    Raises:
+        FileProcessingError: If file doesn't exist or isn't a file
+    """
+    if not filepath.exists():
+        raise FileProcessingError(f"Input file does not exist: {filepath}", str(filepath))
+    if not filepath.is_file():
+        raise FileProcessingError(f"Input path is not a file: {filepath}", str(filepath))
+
+
+def _validate_csv_header(header: list[str]) -> None:
+    """Validates that the CSV header contains required columns.
+    
+    Args:
+        header: List of column names from the CSV header
+        
+    Raises:
+        InvalidFormatError: If required columns are missing
+    """
+    required_columns = {"header", "sequence"}
+    missing_columns = required_columns - set(header)
+    if missing_columns:
+        raise InvalidFormatError(
+            f"Missing required columns: {', '.join(missing_columns)}",
+            "CSV file",
+        )
+
+
+def _raise_invalid_format_error(message: str, filepath_str: str) -> None:
+    """Raises an InvalidFormatError with the given message.
+    
+    Args:
+        message: The error message
+        filepath_str: The filepath as a string
+        
+    Raises:
+        InvalidFormatError: Always raises this exception
+    """
+    raise InvalidFormatError(message, filepath_str)
+
+
+def read_csv_file(filepath: Path) -> Iterator[dict[str, str]]:
+    """Reads a CSV file and yields records as dictionaries.
+
+    Validates file format and content before processing.
+
+    Args:
+        filepath: Path to the CSV file.
+
+    Yields:
+        A dictionary with column names as keys for each record.
+
+    Raises:
+        FileProcessingError: If the file cannot be read.
+        InvalidFormatError: If the file is not in valid CSV format.
+    """
+    _validate_file_exists(filepath)
+
+    try:
+        with open(filepath, newline="", encoding="utf-8") as handle:
+            reader = csv.reader(handle)
+            try:
+                header = next(reader)
+            except StopIteration:
+                _raise_invalid_format_error("File is empty: no CSV records found.", str(filepath))
+            
+            _validate_csv_header(header)
+            
+            for row in reader:
+                if len(row) != len(header):
+                    _raise_invalid_format_error(
+                        f"Row has {len(row)} columns, expected {len(header)}",
+                        str(filepath),
+                    )
+                yield dict(zip(header, row))
+                
+    except FileNotFoundError:
+        raise FileProcessingError(f"File not found: {filepath}", str(filepath)) from None
+    except InvalidFormatError:
+        raise
+    except Exception as e:
+        raise FileProcessingError(f"Error reading file {filepath}: {e}", str(filepath)) from e
+
+
+def create_dataset_from_csv(filepath: Path) -> Dataset:
+    """Creates a Hugging Face Dataset from a CSV file.
+
+    Args:
+        filepath: Path to the CSV file.
+
+    Returns:
+        A Hugging Face Dataset with columns matching the CSV file.
+
+    Raises:
+        FileProcessingError: If the input filepath does not exist or is not a file.
+        InvalidFormatError: If the file is not in valid CSV format.
+    """
+    _validate_file_exists(filepath)
+
+    # Read all records into memory
+    records = list(read_csv_file(filepath))
+
+    if not records:
+        # Create empty dataset with correct features
+        features = Features(
+            {
+                "header": Value("string"),
+                "sequence": Value("string"),
+                "description": Value("string"),
+            },
+        )
+        return Dataset.from_dict({"header": [], "sequence": [], "description": []}, features=features)
+
+    # Create features from the first record
+    features = Features(
+        {
+            key: Value("string")
+            for key in records[0].keys()
+        },
+    )
+
+    def gen() -> Iterator[dict[str, str]]:
+        yield from records
+
+    return Dataset.from_generator(gen, features=features) 

--- a/tests/data/csv/sample.csv
+++ b/tests/data/csv/sample.csv
@@ -1,0 +1,5 @@
+header,sequence,description
+seq1,ATCGATCGATCGATCGATCGATCGATCGATCG,First test sequence
+seq2,GCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTA,Second test sequence
+seq3,TATATATATATATATATATATATATATATATA,Third test sequence
+seq4,CGCGCGCGCGCGCGCGCGCGCGCGCGCGCGCG,Fourth test sequence 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1,0 +1,84 @@
+"""Tests for CSV file processing and conversion."""
+
+import csv
+from pathlib import Path
+
+import pytest
+from datasets import Dataset
+
+from bio2parquet.csv import create_dataset_from_csv
+from bio2parquet.errors import FileProcessingError, InvalidFormatError
+
+
+@pytest.fixture
+def sample_csv_path(tmp_path: Path) -> Path:
+    """Create a sample CSV file for testing.
+    
+    Args:
+        tmp_path: Pytest fixture providing a temporary directory
+        
+    Returns:
+        Path to the created CSV file
+    """
+    csv_path = tmp_path / "test.csv"
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["header", "sequence", "description"])
+        writer.writerow(["seq1", "ATCGATCGATCGATCGATCGATCGATCGATCG", "First test sequence"])
+        writer.writerow(["seq2", "GCTAGCTAGCTAGCTAGCTAGCTAGCTAGCTA", "Second test sequence"])
+    return csv_path
+
+
+def test_create_dataset_from_csv_valid_file(sample_csv_path: Path) -> None:
+    """Test creating a dataset from a valid CSV file."""
+    dataset = create_dataset_from_csv(sample_csv_path)
+    
+    assert isinstance(dataset, Dataset)
+    assert len(dataset) == 2
+    assert dataset.features["header"].dtype == "string"
+    assert dataset.features["sequence"].dtype == "string"
+    assert dataset.features["description"].dtype == "string"
+    
+    # Check first record
+    assert dataset[0]["header"] == "seq1"
+    assert dataset[0]["sequence"] == "ATCGATCGATCGATCGATCGATCGATCGATCG"
+    assert dataset[0]["description"] == "First test sequence"
+
+
+def test_create_dataset_from_csv_missing_file() -> None:
+    """Test creating a dataset from a non-existent file."""
+    with pytest.raises(FileProcessingError):
+        create_dataset_from_csv(Path("nonexistent.csv"))
+
+
+def test_create_dataset_from_csv_invalid_format(tmp_path: Path) -> None:
+    """Test creating a dataset from an invalid CSV file."""
+    csv_path = tmp_path / "invalid.csv"
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["invalid", "columns"])
+    
+    with pytest.raises(InvalidFormatError):
+        create_dataset_from_csv(csv_path)
+
+
+def test_create_dataset_from_csv_empty_file(tmp_path: Path) -> None:
+    """Test creating a dataset from an empty CSV file."""
+    csv_path = tmp_path / "empty.csv"
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["header", "sequence", "description"])
+    
+    dataset = create_dataset_from_csv(csv_path)
+    assert len(dataset) == 0
+
+
+def test_create_dataset_from_csv_missing_required_columns(tmp_path: Path) -> None:
+    """Test creating a dataset from a CSV file missing required columns."""
+    csv_path = tmp_path / "missing_columns.csv"
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["header", "description"])  # Missing sequence column
+    
+    with pytest.raises(InvalidFormatError):
+        create_dataset_from_csv(csv_path) 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -13,10 +13,10 @@ from bio2parquet.errors import FileProcessingError, InvalidFormatError
 @pytest.fixture
 def sample_csv_path(tmp_path: Path) -> Path:
     """Create a sample CSV file for testing.
-    
+
     Args:
         tmp_path: Pytest fixture providing a temporary directory
-        
+
     Returns:
         Path to the created CSV file
     """
@@ -32,13 +32,13 @@ def sample_csv_path(tmp_path: Path) -> Path:
 def test_create_dataset_from_csv_valid_file(sample_csv_path: Path) -> None:
     """Test creating a dataset from a valid CSV file."""
     dataset = create_dataset_from_csv(sample_csv_path)
-    
+
     assert isinstance(dataset, Dataset)
     assert len(dataset) == 2
     assert dataset.features["header"].dtype == "string"
     assert dataset.features["sequence"].dtype == "string"
     assert dataset.features["description"].dtype == "string"
-    
+
     # Check first record
     assert dataset[0]["header"] == "seq1"
     assert dataset[0]["sequence"] == "ATCGATCGATCGATCGATCGATCGATCGATCG"
@@ -57,7 +57,7 @@ def test_create_dataset_from_csv_invalid_format(tmp_path: Path) -> None:
     with open(csv_path, "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["invalid", "columns"])
-    
+
     with pytest.raises(InvalidFormatError):
         create_dataset_from_csv(csv_path)
 
@@ -68,7 +68,7 @@ def test_create_dataset_from_csv_empty_file(tmp_path: Path) -> None:
     with open(csv_path, "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["header", "sequence", "description"])
-    
+
     dataset = create_dataset_from_csv(csv_path)
     assert len(dataset) == 0
 
@@ -79,6 +79,6 @@ def test_create_dataset_from_csv_missing_required_columns(tmp_path: Path) -> Non
     with open(csv_path, "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(["header", "description"])  # Missing sequence column
-    
+
     with pytest.raises(InvalidFormatError):
-        create_dataset_from_csv(csv_path) 
+        create_dataset_from_csv(csv_path)


### PR DESCRIPTION
This PR adds support for converting CSV files to Parquet format, including: - New module for CSV processing and conversion - CLI command for CSV to Parquet conversion - Tests for CSV conversion, including edge cases - Sample CSV test data. All code is linted, tested, and documented.